### PR TITLE
Add Instagram reel support implementation

### DIFF
--- a/frontend/app/api/metadata/route.ts
+++ b/frontend/app/api/metadata/route.ts
@@ -1,5 +1,191 @@
 import { NextResponse } from "next/server";
 import { parse } from "node-html-parser";
+import { spawn } from "child_process";
+import path from "path";
+
+interface VideoMetadata {
+  title?: string;
+  description?: string;
+  image?: string;
+  video?: string;
+  platform?: string;
+  duration?: number;
+  uploader?: string;
+  upload_date?: string;
+  view_count?: number;
+  like_count?: number;
+  width?: number;
+  height?: number;
+}
+
+interface YtDlpInfo {
+  title?: string;
+  description?: string;
+  alt_title?: string;
+  thumbnail?: string;
+  thumbnails?: Array<{
+    url: string;
+    width?: number;
+    height?: number;
+  }>;
+  duration?: number;
+  uploader?: string;
+  channel?: string;
+  upload_date?: string;
+  view_count?: number;
+  like_count?: number;
+  width?: number;
+  height?: number;
+}
+
+function detectPlatform(url: string): 'youtube' | 'instagram' | 'unknown' {
+  if (url.includes('youtube.com') || url.includes('youtu.be')) {
+    return 'youtube';
+  }
+  if (url.includes('instagram.com')) {
+    return 'instagram';
+  }
+  return 'unknown';
+}
+
+function extractInstagramId(url: string): string | null {
+  const regExp = /instagram\.com\/(p|reel|tv)\/([A-Za-z0-9_-]+)/;
+  const match = url.match(regExp);
+  return match ? match[2] : null;
+}
+
+function extractMetadataWithYtDlp(url: string): Promise<YtDlpInfo> {
+  return new Promise((resolve, reject) => {
+    const ytDlpPath = path.resolve(process.cwd(), '../backend/bin/yt-dlp');
+    const platform = detectPlatform(url);
+    
+    const ytArgs = [
+      '-j', // JSON output
+      '--no-warnings',
+      '--no-check-certificates',
+      '--skip-download', // Don't download, just get metadata
+      '--add-header',
+      'user-agent:Mozilla/5.0 (iPhone; CPU iPhone OS 14_6 like Mac OS X) AppleWebKit/605.1.15',
+      url
+    ];
+    
+    if (platform === 'instagram') {
+      ytArgs.push(
+        '--add-header',
+        'referer:instagram.com'
+      );
+    }
+    
+    const yt = spawn(ytDlpPath, ytArgs);
+    
+    let jsonData = '';
+    let errorData = '';
+    
+    yt.stdout.on('data', (data) => {
+      jsonData += data.toString();
+    });
+    
+    yt.stderr.on('data', (data) => {
+      errorData += data.toString();
+    });
+    
+    yt.on('close', (code) => {
+      if (code !== 0) {
+        reject(new Error(`yt-dlp failed: ${errorData}`));
+        return;
+      }
+      
+      try {
+        const info = JSON.parse(jsonData);
+        resolve(info);
+      } catch (e) {
+        reject(new Error(`JSON parse error: ${e instanceof Error ? e.message : String(e)}`));
+      }
+    });
+    
+    // Timeout after 15 seconds
+    setTimeout(() => {
+      yt.kill('SIGKILL');
+      reject(new Error('Timeout'));
+    }, 15000);
+  });
+}
+
+async function extractBasicMetadata(url: string, platform: string): Promise<VideoMetadata> {
+  if (platform === 'instagram') {
+    // Instagram-specific handling
+    const instagramId = extractInstagramId(url);
+    
+    try {
+      // Method 1: fetch with Instagram-specific headers
+      const headers = {
+        'User-Agent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 14_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.3 Mobile/15E148 Safari/604.1',
+        'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+        'Accept-Language': 'en-US,en;q=0.5',
+        'Accept-Encoding': 'gzip, deflate',
+        'Referer': 'https://www.instagram.com/',
+        'DNT': '1',
+        'Connection': 'keep-alive'
+      };
+
+      const res = await fetch(url, { headers });
+      const html = await res.text();
+      const root = parse(html);
+
+      // Extract Open Graph metadata
+      const ogTitle = root.querySelector('meta[property="og:title"]')?.getAttribute("content");
+      const ogDescription = root.querySelector('meta[property="og:description"]')?.getAttribute("content");
+      const ogImage = root.querySelector('meta[property="og:image"]')?.getAttribute("content");
+      const ogVideo = root.querySelector('meta[property="og:video"]')?.getAttribute("content");
+
+      return {
+        title: ogTitle || `Instagram ${instagramId ? 'Post' : 'Content'}`,
+        description: ogDescription || 'Instagram content',
+        image: ogImage,
+        video: ogVideo,
+        platform: 'instagram'
+      };
+    } catch (error) {
+      console.log('Instagram basic metadata failed:', error instanceof Error ? error.message : String(error));
+      return {
+        title: `Instagram ${url.includes('/reel/') ? 'Reel' : url.includes('/p/') ? 'Post' : 'Content'}`,
+        description: 'Instagram content',
+        platform: 'instagram'
+      };
+    }
+  } else {
+    // YouTube and other platforms - original logic
+    try {
+      const res = await fetch(url, {
+        headers: {
+          'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36'
+        }
+      });
+      const html = await res.text();
+      const root = parse(html);
+
+      return {
+        title: root
+          .querySelector('meta[property="og:title"]')
+          ?.getAttribute("content"),
+        description: root
+          .querySelector('meta[property="og:description"]')
+          ?.getAttribute("content"),
+        image: root
+          .querySelector('meta[property="og:image"]')
+          ?.getAttribute("content"),
+        platform: platform
+      };
+    } catch (error) {
+      console.log('Basic metadata extraction failed:', error instanceof Error ? error.message : String(error));
+      return {
+        title: platform === 'youtube' ? 'YouTube Video' : 'Video Content',
+        description: '',
+        platform: platform
+      };
+    }
+  }
+}
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
@@ -9,29 +195,65 @@ export async function GET(request: Request) {
     return NextResponse.json({ error: "URL is required" }, { status: 400 });
   }
 
+  const platform = detectPlatform(url);
+  
+  if (platform === 'unknown') {
+    return NextResponse.json({ error: "Unsupported platform" }, { status: 400 });
+  }
+
   try {
-    const res = await fetch(url);
-    const html = await res.text();
-    const root = parse(html);
-
-    const metadata = {
-      title: root
-        .querySelector('meta[property="og:title"]')
-        ?.getAttribute("content"),
-      description: root
-        .querySelector('meta[property="og:description"]')
-        ?.getAttribute("content"),
-      image: root
-        .querySelector('meta[property="og:image"]')
-        ?.getAttribute("content"),
-    };
-
-    return NextResponse.json(metadata);
+    // Primary method: Try yt-dlp for rich metadata (duration, uploader, etc.)
+    try {
+      const info = await extractMetadataWithYtDlp(url);
+      
+      // Extract relevant metadata from yt-dlp
+      const metadata: VideoMetadata = {
+        title: info.title || `${platform === 'instagram' ? 'Instagram' : 'Video'} Content`,
+        description: info.description || info.alt_title || '',
+        image: info.thumbnail || info.thumbnails?.[0]?.url || undefined,
+        duration: info.duration || undefined,
+        uploader: info.uploader || info.channel || undefined,
+        upload_date: info.upload_date || undefined,
+        view_count: info.view_count || undefined,
+        like_count: info.like_count || undefined,
+        platform: platform,
+        width: info.width || undefined,
+        height: info.height || undefined
+      };
+      
+      // For Instagram, try to get the best thumbnail
+      if (platform === 'instagram' && info.thumbnails && info.thumbnails.length > 0) {
+        // Sort thumbnails by quality (prefer larger ones)
+        const sortedThumbnails = info.thumbnails.sort((a, b) => {
+          const aSize = (a.width || 0) * (a.height || 0);
+          const bSize = (b.width || 0) * (b.height || 0);
+          return bSize - aSize;
+        });
+        metadata.image = sortedThumbnails[0]?.url || metadata.image;
+      }
+      
+      return NextResponse.json(metadata);
+      
+    } catch (ytdlpError) {
+      console.log(`yt-dlp extraction failed for ${platform}, falling back to basic scraping:`, ytdlpError instanceof Error ? ytdlpError.message : String(ytdlpError));
+      
+      // Fallback method: Basic HTML scraping
+      const basicMetadata = await extractBasicMetadata(url, platform);
+      return NextResponse.json(basicMetadata);
+    }
+    
   } catch (error) {
     console.error("Error fetching metadata:", error);
-    return NextResponse.json(
-      { error: "Failed to fetch metadata" },
-      { status: 500 }
-    );
+    
+    // Final fallback metadata
+    const fallbackMetadata: VideoMetadata = {
+      title: platform === 'instagram' 
+        ? `Instagram ${url.includes('/reel/') ? 'Reel' : 'Content'}` 
+        : 'Video Content',
+      description: '',
+      platform: platform
+    };
+    
+    return NextResponse.json(fallbackMetadata);
   }
 }

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -48,8 +48,8 @@ export default function App() {
             animate="animate"
             transition={{ duration: 0.5, delay: 0.1 }}
           >
-            Clippa is your platform for YT clips. Create bangers from your
-            favorite moments from videos.
+            Clippa is your platform for creating clips from YouTube and Instagram. Create bangers from your
+            favorite moments.
           </motion.p>
         </div>
 

--- a/frontend/drizzle/0001_bent_lightspeed.sql
+++ b/frontend/drizzle/0001_bent_lightspeed.sql
@@ -1,0 +1,9 @@
+CREATE TABLE "payment" (
+	"id" text PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"status" text NOT NULL,
+	"created_at" timestamp NOT NULL,
+	"updated_at" timestamp NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "payment" ADD CONSTRAINT "payment_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;

--- a/frontend/drizzle/meta/0001_snapshot.json
+++ b/frontend/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,376 @@
+{
+  "id": "a14e8da0-17eb-4c8e-ad8c-4724f99bcf23",
+  "prevId": "80e329ef-4c3a-4fcf-b626-c75f615b0ca0",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment": {
+      "name": "payment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "payment_user_id_user_id_fk": {
+          "name": "payment_user_id_user_id_fk",
+          "tableFrom": "payment",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/frontend/drizzle/meta/_journal.json
+++ b/frontend/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1746970952920,
       "tag": "0000_chunky_doctor_doom",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1750623886807,
+      "tag": "0001_bent_lightspeed",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
Hey @retrogtx ! I was playing around with the youtube-clipper (Clippa) and thought it might be cool to extend it to Instagram reels. Not sure if this is something you're looking to add, but here's an implementation if it is!

- Modified backend/src/index.ts for IG reel processing
- Updated frontend editor for IG reel functionality
- Enhanced metadata API route for Instagram content
- Updated main page for IG reel features
- Added database migration for new schema changes


https://github.com/user-attachments/assets/d2b4af88-6ca0-499f-a844-260061b0f26d
